### PR TITLE
Add deprecation line to autotriage directory

### DIFF
--- a/autotriage/README.md
+++ b/autotriage/README.md
@@ -1,3 +1,5 @@
+DEPRECATED
+
 # Autotriage utility
 
 This tool assists the Hardware Management Services team by using kubernetes and


### PR DESCRIPTION
Autotriage is not used nor will it be continued to be updated.
