### PR TITLE
Add deprecation line to hwval directory

### DIFF
--- a/hwval/README.md
+++ b/hwval/README.md
@@ -1,3 +1,5 @@
+DEPRECATED
+
 # Hardware Validation Tool
 
 This tool assists the Hardware Management Services team by using kubernetes and


### PR DESCRIPTION
Hwval has been made obsolete by process changes in hardware validation and will no longer be updated.
