### PR TITLE
Fix Deep PATCH for Olympus nodes

### DIFF
--- a/validation/test_power_capping.py
+++ b/validation/test_power_capping.py
@@ -91,15 +91,17 @@ def makeRedfishCall(args, action, targPath, reqData=None):
     elif action == "DELETE":
         r = requests.delete(url = targPath, auth = auth, verify = False)
     elif action == "PATCH":
-        rsp = requests.get(url = targPath, auth = auth, headers = headers,
-                verify = False)
+        # Olympus nodes don't need the etag for the PATCH
+        if ".Deep" not in targPath:
+            rsp = requests.get(url = targPath, auth = auth, headers = headers,
+                    verify = False)
 
-        if rsp.status_code >= 300:
-            print("Redfish call to get power structure failed for %s." % targPath)
-            return None
+            if rsp.status_code >= 300:
+                print("Redfish call to get power structure failed for %s." % targPath)
+                return None
 
-        power = json.loads(rsp.text)
-        headers['If-Match'] = power['@odata.etag']
+            power = json.loads(rsp.text)
+            headers['If-Match'] = power['@odata.etag']
 
         r = requests.patch(url = targPath, auth = auth, headers = headers,
                 data = reqData, verify = False)

--- a/validation/test_power_capping.py
+++ b/validation/test_power_capping.py
@@ -51,7 +51,7 @@ import json
 import requests
 import urllib3
 
-VERSION="1.0.0"
+VERSION="1.0.1"
 
 
 def makeRedfishCall(args, action, targPath, reqData=None):


### PR DESCRIPTION
## Summary and Scope

A bug was introduced for Olympus power cap testing when adding code to support Gigabyte and HPE power caps. Made the query of the etag only needed for non-Deep PATCH requests.

## Issues and Related PRs

* Resolves [CASMHMS-5790](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5790)

## Testing

### Tested on:

  * `loki`

### Test description:

Executed updated script against Olympus nodes to verify power cap testing worked again.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

